### PR TITLE
fix: update TemplateResponse calls to new Starlette keyword argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ templates = Jinja2Templates(directory="templates")
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     print('Request for index page received')
-    return templates.TemplateResponse('index.html', {"request": request})
+    return templates.TemplateResponse(request=request, name='index.html')
 
 @app.get('/favicon.ico')
 async def favicon():
@@ -24,7 +24,7 @@ async def favicon():
 async def hello(request: Request, name: str = Form(...)):
     if name:
         print('Request for hello page received with name=%s' % name)
-        return templates.TemplateResponse('hello.html', {"request": request, 'name':name})
+        return templates.TemplateResponse(request=request, name='hello.html', context={'name':name})
     else:
         print('Request for hello page received with no name or blank name -- redirecting')
         return RedirectResponse(request.url_for("index"), status_code=status.HTTP_302_FOUND)


### PR DESCRIPTION
Starlette's TemplateResponse signature changed in newer versions with `request` and `name` now being required keyword arguments instead of being passed inside the context dict.

Updated both the '/' and '/hello' endpoints.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Resolves exceptions raised in both of the applications endpoints preventing it from displaying.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  Run the application

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
uvicorn main:app --reload
```

## What to Check
Verify that the following are valid
* Application loads successfully
* Input is displayed as name after clicking button
* No errors occur in the server

## Other Information
<!-- Add any other helpful information that may be needed here. -->